### PR TITLE
Break background serve out of parent job on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6723,7 +6723,7 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/rest_api_cli/Cargo.toml
+++ b/crates/rest_api_cli/Cargo.toml
@@ -64,7 +64,7 @@ garde.workspace = true
 jsonwebtoken.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Threading"] }
 
 [lib]
 name = "vsra"

--- a/crates/rest_api_cli/src/commands/serve_manager.rs
+++ b/crates/rest_api_cli/src/commands/serve_manager.rs
@@ -43,6 +43,12 @@ const PROCESS_SYNCHRONIZE_RIGHT: u32 = 0x0010_0000;
 const DETACHED_PROCESS_FLAG: u32 = 0x0000_0008;
 #[cfg(windows)]
 const CREATE_NEW_PROCESS_GROUP_FLAG: u32 = 0x0000_0200;
+#[cfg(windows)]
+const CREATE_NO_WINDOW_FLAG: u32 = 0x0800_0000;
+#[cfg(windows)]
+const CREATE_BREAKAWAY_FROM_JOB_FLAG: u32 = 0x0100_0000;
+#[cfg(windows)]
+const ERROR_ACCESS_DENIED: i32 = 5;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -271,10 +277,15 @@ pub fn spawn_background_serve(
     #[cfg(windows)]
     {
         clear_standard_handle_inheritance()?;
-        command.creation_flags(DETACHED_PROCESS_FLAG | CREATE_NEW_PROCESS_GROUP_FLAG);
+        command.creation_flags(
+            DETACHED_PROCESS_FLAG
+                | CREATE_NEW_PROCESS_GROUP_FLAG
+                | CREATE_NO_WINDOW_FLAG
+                | CREATE_BREAKAWAY_FROM_JOB_FLAG,
+        );
     }
 
-    let mut child = command.spawn().with_context(|| {
+    let mut child = spawn_background_child(&mut command).with_context(|| {
         format!(
             "failed to start background `vsr serve` for {}",
             input.display()
@@ -856,6 +867,30 @@ fn process_is_running(pid: u32) -> anyhow::Result<bool> {
             .status()
             .context("failed to invoke kill -0")?;
         Ok(status.success())
+    }
+}
+
+fn spawn_background_child(command: &mut Command) -> std::io::Result<std::process::Child> {
+    #[cfg(windows)]
+    {
+        match command.spawn() {
+            Ok(child) => Ok(child),
+            Err(error) if error.raw_os_error() == Some(ERROR_ACCESS_DENIED) => {
+                log::debug!(
+                    "CreateProcess rejected CREATE_BREAKAWAY_FROM_JOB; retrying without it"
+                );
+                command.creation_flags(
+                    DETACHED_PROCESS_FLAG | CREATE_NEW_PROCESS_GROUP_FLAG | CREATE_NO_WINDOW_FLAG,
+                );
+                command.spawn()
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        command.spawn()
     }
 }
 


### PR DESCRIPTION
## Summary
- `vsr serve --bg` was dying instantly on Windows (symptom: child exits with no log output). Root cause: Windows Terminal / VS Code / PowerShell host place spawned processes into a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. `DETACHED_PROCESS` alone doesn't escape the job — when the `vsr serve --bg` parent returned, Windows tore down the job and killed the child.
- Add `CREATE_BREAKAWAY_FROM_JOB` (and `CREATE_NO_WINDOW`) to the detached spawn. If the ambient job disallows breakaway, the spawn retries with the original flag set so we don't regress to a hard `ERROR_ACCESS_DENIED` failure.
- Bump `vsra`'s `windows-sys` from `0.59` to `0.61` to match the rest of the workspace (drops the stale `windows-targets` tree, relevant on ARM64).

## Test plan
- [ ] `cargo check -p vsra` (done locally — clean)
- [ ] On Windows 11: run `vsr serve --bg <eon>` from Windows Terminal, confirm `vsr status` still shows it after 10s
- [ ] On Windows 11: run `vsr serve --bg <eon>` from VS Code integrated terminal, confirm the child survives closing the terminal
- [ ] `cargo test -p vsra --test serve_cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)