### PR TITLE
Serve auth UI pages at absolute paths outside /api

### DIFF
--- a/crates/rest_api_cli/src/commands/check.rs
+++ b/crates/rest_api_cli/src/commands/check.rs
@@ -297,68 +297,30 @@ fn auth_ui_path_findings(service: &ServiceSpec) -> Vec<CheckFinding> {
         let Some(path) = path else {
             continue;
         };
-        let external_path = auth_ui_external_path(path);
 
-        if let Some(resource_name) = auth_ui_resource_namespace_overlap(service, path) {
+        if path_is_inside_api_namespace(path) {
             findings.push(CheckFinding {
-                code: "security.auth.ui_path_overlaps_resource_namespace".to_owned(),
+                code: "security.auth.ui_path_inside_api_namespace".to_owned(),
                 severity: CheckSeverity::Warning,
                 path: format!("security.auth.{label}.path"),
                 message: format!(
-                    "built-in auth UI path `{path}` shares the `/api/{}` namespace with resource `{}`",
-                    resource_name, resource_name
+                    "built-in auth UI path `{path}` is nested under `/api`, which requires anonymous client keys and blocks browser loads"
                 ),
                 suggestion: Some(
-                    "Move the auth UI path outside resource namespaces, for example under `/auth/...`, so built-in pages do not shadow generated resource routes."
-                        .to_owned(),
-                ),
-            });
-        }
-
-        if let Some(upload_name) = auth_ui_upload_namespace_overlap(service, path) {
-            findings.push(CheckFinding {
-                code: "security.auth.ui_path_overlaps_upload_namespace".to_owned(),
-                severity: CheckSeverity::Warning,
-                path: format!("security.auth.{label}.path"),
-                message: format!(
-                    "built-in auth UI path `{path}` shares the `/api` namespace used by storage upload `{upload_name}`",
-                ),
-                suggestion: Some(
-                    "Move the auth UI path or the upload route so each owns a distinct first path segment inside `/api`."
-                        .to_owned(),
-                ),
-            });
-        }
-
-        if service.authorization.management_api.enabled
-            && auth_ui_matches_or_overlaps(
-                path,
-                service.authorization.management_api.mount.as_str(),
-            )
-        {
-            findings.push(CheckFinding {
-                code: "security.auth.ui_path_overlaps_authorization_management".to_owned(),
-                severity: CheckSeverity::Warning,
-                path: format!("security.auth.{label}.path"),
-                message: format!(
-                    "built-in auth UI path `{path}` overlaps the authorization management mount `{}` inside `/api`",
-                    service.authorization.management_api.mount
-                ),
-                suggestion: Some(
-                    "Keep auth UI pages and runtime authorization management under separate `/api` prefixes."
+                    "Configure the auth UI path as an absolute path outside `/api`, for example under `/auth/...`, so browsers can reach the page without an anonymous client key header."
                         .to_owned(),
                 ),
             });
         }
 
         for mount in &service.static_mounts {
-            if auth_ui_matches_or_overlaps(external_path.as_str(), mount.mount_path.as_str()) {
+            if auth_ui_matches_or_overlaps(path, mount.mount_path.as_str()) {
                 findings.push(CheckFinding {
                     code: "security.auth.ui_path_overlaps_static_mount".to_owned(),
                     severity: CheckSeverity::Warning,
                     path: format!("security.auth.{label}.path"),
                     message: format!(
-                        "built-in auth UI path `{external_path}` overlaps static mount `{}`",
+                        "built-in auth UI path `{path}` overlaps static mount `{}`",
                         mount.mount_path
                     ),
                     suggestion: Some(
@@ -373,44 +335,8 @@ fn auth_ui_path_findings(service: &ServiceSpec) -> Vec<CheckFinding> {
     findings
 }
 
-fn auth_ui_external_path(path: &str) -> String {
-    if path == "/" {
-        "/api".to_owned()
-    } else {
-        format!("/api{path}")
-    }
-}
-
-fn auth_ui_resource_namespace_overlap(service: &ServiceSpec, path: &str) -> Option<String> {
-    let first_segment = first_path_segment(path)?;
-    service
-        .resources
-        .iter()
-        .find(|resource| resource.api_name() == first_segment)
-        .map(|resource| resource.api_name().to_owned())
-}
-
-fn auth_ui_upload_namespace_overlap(service: &ServiceSpec, path: &str) -> Option<String> {
-    let first_segment = first_path_segment(path)?;
-    service
-        .storage
-        .uploads
-        .iter()
-        .find(|upload| {
-            upload
-                .path
-                .split('/')
-                .next()
-                .map(|segment| segment == first_segment)
-                .unwrap_or(false)
-        })
-        .map(|upload| upload.name.clone())
-}
-
-fn first_path_segment(path: &str) -> Option<&str> {
-    path.trim_matches('/')
-        .split('/')
-        .find(|segment| !segment.is_empty())
+fn path_is_inside_api_namespace(path: &str) -> bool {
+    path == "/api" || path.starts_with("/api/")
 }
 
 fn auth_ui_matches_or_overlaps(left: &str, right: &str) -> bool {
@@ -2098,7 +2024,7 @@ authorization: {
 static: {
     mounts: [
         {
-            mount: "/api/auth/portal"
+            mount: "/auth/portal"
             dir: "public"
             mode: Spa
             cache: NoStore
@@ -2124,11 +2050,11 @@ storage: {
 security: {
     auth: {
         portal: {
-            path: "/note"
+            path: "/auth/portal"
             title: "Portal"
         }
         admin_dashboard: {
-            path: "/ops/authz"
+            path: "/api/admin"
             title: "Admin Dashboard"
         }
     }
@@ -2151,13 +2077,13 @@ resources: [
             .iter()
             .map(|finding| finding.code.as_str())
             .collect::<Vec<_>>();
-        assert!(codes.contains(&"security.auth.ui_path_overlaps_resource_namespace"));
-        assert!(codes.contains(&"security.auth.ui_path_overlaps_authorization_management"));
+        assert!(codes.contains(&"security.auth.ui_path_overlaps_static_mount"));
+        assert!(codes.contains(&"security.auth.ui_path_inside_api_namespace"));
 
         let rendered =
             render_service_check_report(&report, OutputFormat::Text).expect("text should render");
-        assert!(rendered.contains("security.auth.ui_path_overlaps_resource_namespace"));
-        assert!(rendered.contains("security.auth.ui_path_overlaps_authorization_management"));
+        assert!(rendered.contains("security.auth.ui_path_overlaps_static_mount"));
+        assert!(rendered.contains("security.auth.ui_path_inside_api_namespace"));
     }
 
     #[test]
@@ -2178,7 +2104,7 @@ authorization: {
 static: {
     mounts: [
         {
-            mount: "/api/auth/portal"
+            mount: "/auth/portal"
             dir: "public"
             mode: Spa
             cache: NoStore
@@ -2208,7 +2134,7 @@ security: {
             title: "Portal"
         }
         admin_dashboard: {
-            path: "/dashboard"
+            path: "/api/admin"
             title: "Admin Dashboard"
         }
     }

--- a/crates/rest_api_cli/src/commands/serve.rs
+++ b/crates/rest_api_cli/src/commands/serve.rs
@@ -87,6 +87,7 @@ pub async fn serve_service(
 
     let mut logger = service.logging.build_env_logger();
     let _ = logger.try_init();
+    install_diagnostic_panic_hook();
 
     if include_builtin_auth {
         auth::ensure_jwt_secret_configured_with_settings(&service.security.auth)
@@ -190,12 +191,16 @@ pub async fn serve_service(
                         }
                     }),
                 )
-                .configure(move |cfg| {
-                    if include_builtin_auth {
-                        auth::public_auth_discovery_routes_with_settings(
-                            cfg,
-                            api_security.auth.clone(),
-                        );
+                .configure({
+                    let auth_settings = api_security.auth.clone();
+                    move |cfg| {
+                        if include_builtin_auth {
+                            auth::public_auth_discovery_routes_with_settings(
+                                cfg,
+                                auth_settings.clone(),
+                            );
+                            auth::register_builtin_auth_html_pages(cfg, auth_settings);
+                        }
                     }
                 })
                 .service(
@@ -259,6 +264,36 @@ pub async fn serve_service(
     server_result?;
 
     Ok(())
+}
+
+fn install_diagnostic_panic_hook() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let payload = info.payload();
+            let message = payload
+                .downcast_ref::<&'static str>()
+                .copied()
+                .map(ToOwned::to_owned)
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "<non-string panic payload>".to_owned());
+            let location = info
+                .location()
+                .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+                .unwrap_or_else(|| "<unknown location>".to_owned());
+            let thread = std::thread::current();
+            let thread_name = thread.name().unwrap_or("<unnamed>");
+            log::error!(
+                "vsr panic on thread '{thread_name}' at {location}: {message}"
+            );
+            eprintln!(
+                "[vsr panic] thread='{thread_name}' at {location}: {message}"
+            );
+            default_hook(info);
+        }));
+    });
 }
 
 fn spawn_parent_shutdown_watch(server_handle: actix_web::dev::ServerHandle, enabled: bool) {

--- a/crates/rest_api_cli/src/commands/server.rs
+++ b/crates/rest_api_cli/src/commands/server.rs
@@ -3753,7 +3753,7 @@ resources: [
         assert_eq!(admin_requests.get("total").and_then(Value::as_i64), Some(1));
 
         let portal_response = client
-            .get(format!("{base_url}/api/auth/portal"))
+            .get(format!("{base_url}/auth/portal"))
             .send()
             .expect("account portal should load");
         assert_eq!(portal_response.status(), reqwest::StatusCode::OK);
@@ -3761,7 +3761,7 @@ resources: [
         assert!(portal_body.contains("Bridgeboard Account"));
 
         let dashboard_response = client
-            .get(format!("{base_url}/api/auth/admin"))
+            .get(format!("{base_url}/auth/admin"))
             .bearer_auth(&admin_token)
             .send()
             .expect("admin dashboard should load");

--- a/crates/rest_api_cli/tests/serve_cli.rs
+++ b/crates/rest_api_cli/tests/serve_cli.rs
@@ -1050,7 +1050,7 @@ fn vsr_serve_supports_builtin_auth_portal_dashboard_and_admin_users() {
     );
 
     let portal_response = client
-        .get(format!("{base_url}/api/auth/portal"))
+        .get(format!("{base_url}/auth/portal"))
         .send()
         .expect("account portal should load");
     assert_eq!(portal_response.status(), reqwest::StatusCode::OK);
@@ -1058,7 +1058,7 @@ fn vsr_serve_supports_builtin_auth_portal_dashboard_and_admin_users() {
     assert!(portal_body.contains("Account Portal"));
 
     let unauthorized_admin_page = client
-        .get(format!("{base_url}/api/auth/admin"))
+        .get(format!("{base_url}/auth/admin"))
         .send()
         .expect("admin page should respond");
     assert_eq!(
@@ -1082,7 +1082,7 @@ fn vsr_serve_supports_builtin_auth_portal_dashboard_and_admin_users() {
         .to_owned();
 
     let admin_page_response = client
-        .get(format!("{base_url}/api/auth/admin"))
+        .get(format!("{base_url}/auth/admin"))
         .bearer_auth(&token)
         .send()
         .expect("admin dashboard should load");
@@ -4168,7 +4168,7 @@ fn vsr_serve_bridgeboard_example_supports_clean_room_e2e() {
     assert_eq!(admin_requests.get("total").and_then(Value::as_i64), Some(1));
 
     let portal_response = client
-        .get(format!("{base_url}/api/auth/portal"))
+        .get(format!("{base_url}/auth/portal"))
         .send()
         .expect("account portal should load");
     assert_eq!(portal_response.status(), reqwest::StatusCode::OK);
@@ -4176,7 +4176,7 @@ fn vsr_serve_bridgeboard_example_supports_clean_room_e2e() {
     assert!(portal_body.contains("Bridgeboard Account"));
 
     let dashboard_response = client
-        .get(format!("{base_url}/api/auth/admin"))
+        .get(format!("{base_url}/auth/admin"))
         .bearer_auth(&admin_token)
         .send()
         .expect("admin dashboard should load");

--- a/crates/rest_api_cli/tests/snapshots/check/auth_ui_path_collision_api.txt
+++ b/crates/rest_api_cli/tests/snapshots/check/auth_ui_path_collision_api.txt
@@ -6,7 +6,7 @@ Warnings: 3
 Findings:
 - [Warning] authorization.management_api_without_targets at `authorization.management_api`: authorization management API is enabled, but no permissions or templates are declared
   Suggestion: Declare `authorization.permissions` or `authorization.templates`, or disable the management API until runtime assignments are modeled.
-- [Warning] security.auth.ui_path_overlaps_static_mount at `security.auth.portal.path`: built-in auth UI path `/api/auth/portal` overlaps static mount `/api/auth/portal`
+- [Warning] security.auth.ui_path_overlaps_static_mount at `security.auth.portal.path`: built-in auth UI path `/auth/portal` overlaps static mount `/auth/portal`
   Suggestion: Move the static mount or auth UI page so a root-level static handler cannot shadow the built-in auth UI route.
-- [Warning] security.auth.ui_path_overlaps_upload_namespace at `security.auth.admin_dashboard.path`: built-in auth UI path `/dashboard` shares the `/api` namespace used by storage upload `dashboard_upload`
-  Suggestion: Move the auth UI path or the upload route so each owns a distinct first path segment inside `/api`.
+- [Warning] security.auth.ui_path_inside_api_namespace at `security.auth.admin_dashboard.path`: built-in auth UI path `/api/admin` is nested under `/api`, which requires anonymous client keys and blocks browser loads
+  Suggestion: Configure the auth UI path as an absolute path outside `/api`, for example under `/auth/...`, so browsers can reach the page without an anonymous client key header.

--- a/crates/rest_macro_core/src/auth.rs
+++ b/crates/rest_macro_core/src/auth.rs
@@ -4405,8 +4405,16 @@ fn prompt_admin_credentials() -> (String, String) {
     // Prompt for email
     let mut email = String::new();
     print!("Admin email: ");
-    stdout().flush().unwrap();
-    stdin().read_line(&mut email).unwrap();
+    if let Err(error) = stdout().flush() {
+        eprintln!("[ERROR] Failed to flush stdout while prompting for admin email: {error}");
+        println!("[WARN] Using default admin credentials as fallback.");
+        return create_default_admin();
+    }
+    if let Err(error) = stdin().read_line(&mut email) {
+        eprintln!("[ERROR] Failed to read admin email from stdin: {error}");
+        println!("[WARN] Using default admin credentials as fallback.");
+        return create_default_admin();
+    }
     let email = email.trim().to_string();
 
     // Prompt for password securely (no echo)
@@ -4489,14 +4497,32 @@ pub fn auth_routes_with_settings(
     auth_api_routes_with_settings(cfg, db, settings);
 }
 
+/// Registers the account portal and admin dashboard HTML pages at their
+/// configured absolute paths. These pages are meant to be loaded directly by a
+/// browser, so they must be mounted OUTSIDE any scope guarded by the anonymous
+/// client middleware. Safe to call at the `App::configure` level.
+pub fn register_builtin_auth_html_pages(cfg: &mut web::ServiceConfig, settings: AuthSettings) {
+    let portal = settings.portal.clone();
+    let admin_dashboard = settings.admin_dashboard.clone();
+    cfg.app_data(web::Data::new(settings));
+
+    if let Some(portal) = portal {
+        cfg.route(portal.path.as_str(), web::get().to(account_portal_page));
+    }
+    if let Some(dashboard) = admin_dashboard {
+        cfg.route(
+            dashboard.path.as_str(),
+            web::get().to(admin_dashboard_page),
+        );
+    }
+}
+
 pub fn auth_api_routes_with_settings(
     cfg: &mut web::ServiceConfig,
     db: impl Into<DbPool>,
     settings: AuthSettings,
 ) {
     let db = web::Data::new(db.into());
-    let enable_portal = settings.portal.clone();
-    let enable_admin_dashboard = settings.admin_dashboard.clone();
     let settings = web::Data::new(settings);
     let limiter = web::Data::new(AuthRateLimiter::default());
     errors::configure_extractor_errors(cfg);
@@ -4544,13 +4570,6 @@ pub fn auth_api_routes_with_settings(
         "/auth/admin/users/{id}/verification",
         web::post().to(resend_managed_user_verification),
     );
-
-    if let Some(portal) = enable_portal {
-        cfg.route(portal.path.as_str(), web::get().to(account_portal_page));
-    }
-    if let Some(dashboard) = enable_admin_dashboard {
-        cfg.route(dashboard.path.as_str(), web::get().to(admin_dashboard_page));
-    }
 }
 
 fn auth_settings_from_request(req: &HttpRequest) -> AuthSettings {

--- a/examples/bridgeboard/README.md
+++ b/examples/bridgeboard/README.md
@@ -79,8 +79,8 @@ provider: {
 
 Bridgeboard enables the built-in HTML pages as part of the example:
 
-- Account portal: `https://127.0.0.1:8443/api/auth/portal`
-- Admin dashboard: `https://127.0.0.1:8443/api/auth/admin`
+- Account portal: `https://127.0.0.1:8443/auth/portal`
+- Admin dashboard: `https://127.0.0.1:8443/auth/admin`
 
 The browser client also exposes:
 

--- a/examples/bridgeboard/public/app.js
+++ b/examples/bridgeboard/public/app.js
@@ -28,8 +28,8 @@ import {
   updateCollaborationRequest as updateCollaborationRequestOperation,
 } from "./gen/client/index.js";
 
-const AUTH_PORTAL_URL = "/api/auth/portal";
-const AUTH_ADMIN_URL = "/api/auth/admin";
+const AUTH_PORTAL_URL = "/auth/portal";
+const AUTH_ADMIN_URL = "/auth/admin";
 const CSRF_COOKIE_NAME = "vsr_csrf";
 const MOBILE_NAV_BREAKPOINT = 980;
 const ROUTE_ORDER = new Map([

--- a/examples/bridgeboard/public/index.html
+++ b/examples/bridgeboard/public/index.html
@@ -57,7 +57,7 @@
                     <a
                         id="portalLink"
                         class="header-link ghost"
-                        href="/api/auth/portal"
+                        href="/auth/portal"
                         target="_blank"
                         rel="noreferrer"
                     >
@@ -66,7 +66,7 @@
                     <a
                         id="builtinAdminLink"
                         class="header-link ghost"
-                        href="/api/auth/admin"
+                        href="/auth/admin"
                         target="_blank"
                         rel="noreferrer"
                         hidden
@@ -138,7 +138,7 @@
                         <a
                             id="mobilePortalLink"
                             class="header-link ghost"
-                            href="/api/auth/portal"
+                            href="/auth/portal"
                             target="_blank"
                             rel="noreferrer"
                         >
@@ -147,7 +147,7 @@
                         <a
                             id="mobileBuiltinAdminLink"
                             class="header-link ghost"
-                            href="/api/auth/admin"
+                            href="/auth/admin"
                             target="_blank"
                             rel="noreferrer"
                             hidden

--- a/examples/family_app/public/index.html
+++ b/examples/family_app/public/index.html
@@ -35,8 +35,8 @@
             </div>
 
             <div class="masthead-links">
-                <a class="chrome-link" href="/api/auth/portal" target="_blank" rel="noreferrer">Portal</a>
-                <a class="chrome-link" href="/api/auth/admin" target="_blank" rel="noreferrer">Admin</a>
+                <a class="chrome-link" href="/auth/portal" target="_blank" rel="noreferrer">Portal</a>
+                <a class="chrome-link" href="/auth/admin" target="_blank" rel="noreferrer">Admin</a>
                 <a class="chrome-link" href="/openapi.json" target="_blank" rel="noreferrer">OpenAPI</a>
             </div>
         </header>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,9 +197,9 @@ pub mod auth {
         auth_routes_with_settings, change_password, confirm_password_reset, create_managed_user,
         delete_managed_user, ensure_admin_exists, ensure_admin_exists_with_settings,
         ensure_jwt_secret_configured, list_managed_users, login, login_with_request, logout,
-        managed_user, me, register, request_password_reset, resend_account_verification,
-        resend_managed_user_verification, resend_verification, update_managed_user,
-        validate_auth_claim_mappings, verify_email_page, verify_email_token,
+        managed_user, me, register, register_builtin_auth_html_pages, request_password_reset,
+        resend_account_verification, resend_managed_user_verification, resend_verification,
+        update_managed_user, validate_auth_claim_mappings, verify_email_page, verify_email_token,
     };
 }
 

--- a/tests/auth_management.rs
+++ b/tests/auth_management.rs
@@ -172,10 +172,16 @@ async fn built_in_auth_management_supports_verification_reset_and_dashboards() {
         .as_mut()
         .expect("auth management fixture should define email settings")
         .public_base_url = Some("https://app.example".to_owned());
-    let app = test::init_service(App::new().service(scope("/api").configure(|cfg| {
-        auth::auth_routes_with_settings(cfg, pool.clone(), security.auth.clone());
-        auth_management_api::configure(cfg, pool.clone());
-    })))
+    let app = test::init_service(
+        App::new()
+            .configure(|cfg| {
+                auth::register_builtin_auth_html_pages(cfg, security.auth.clone());
+            })
+            .service(scope("/api").configure(|cfg| {
+                auth::auth_routes_with_settings(cfg, pool.clone(), security.auth.clone());
+                auth_management_api::configure(cfg, pool.clone());
+            })),
+    )
     .await;
 
     let register_alice = test::TestRequest::post()
@@ -262,7 +268,7 @@ async fn built_in_auth_management_supports_verification_reset_and_dashboards() {
     assert!(account_body.email_verified);
 
     let portal_request = test::TestRequest::get()
-        .uri("/api/auth/portal")
+        .uri("/auth/portal")
         .to_request();
     let portal_response = test::call_service(&app, portal_request).await;
     assert_eq!(portal_response.status(), StatusCode::OK);
@@ -336,7 +342,7 @@ async fn built_in_auth_management_supports_verification_reset_and_dashboards() {
     );
 
     let admin_page_request = test::TestRequest::get()
-        .uri("/api/auth/admin")
+        .uri("/auth/admin")
         .insert_header(("Authorization", format!("Bearer {}", token_body.token)))
         .to_request();
     let admin_page_response = test::call_service(&app, admin_page_request).await;


### PR DESCRIPTION
The built-in account portal and admin dashboard HTML pages lived inside the `/api` scope that enforces anon-client-key middleware. Browsers cannot set that header, so opening `/api/auth/portal` from a browser returned `invalid_anon_client`. Move the HTML pages to their configured absolute paths at the App level via a new `register_builtin_auth_html_pages` helper, and keep the JSON admin APIs under `/api/auth/admin/users`. Also install a diagnostic panic hook in `serve_service` to surface silent crashes, and stop `prompt_admin_credentials` from panicking on stdin I/O errors.

Update `cargo check` auth UI path overlap heuristics for the new absolute-path layout, refresh the snapshot and fixtures, and propagate the URL change through the bridgeboard/family_app examples and docs.